### PR TITLE
GameManager Urn Model

### DIFF
--- a/Assets/OrangeBehavior.cs
+++ b/Assets/OrangeBehavior.cs
@@ -28,10 +28,10 @@ public class OrangeBehavior : MonoBehaviour
     }
 
     public void onGameDecision(GameDecisionData decisionData) {
-        if (decisionData.decision == InputTypes.AcceptAllInput) {
+        if (decisionData.decision == TrialType.AccInput) {
             ActivateSuccessFeedback();
             //Debug.Log("Showing Feedback from Real Input.");
-        } else if (decisionData.decision == InputTypes.FabInput) {
+        } else if (decisionData.decision == TrialType.FabInput) {
             ActivateSuccessFeedback();
             //Debug.Log("Showing Feedback from Fabricated Input.");
         } else {

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2538,6 +2538,7 @@ GameObject:
   - component: {fileID: 1552617764}
   - component: {fileID: 1552617761}
   - component: {fileID: 1552617762}
+  - component: {fileID: 1552617763}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -2557,12 +2558,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ab27ba71bd6f5fa43bf6d4ad3d916c71, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  setupType: 0
+  rejTrials: 1
+  accTrials: 2
+  fabTrials: 2
   noInputReceivedFabAlarm: 3
   fabAlarmVariability: 1.9
-  startPolicyReview: 0.4
-  trials: 20
-  gamePolicy: 1
   interTrialIntervalSeconds: 2
   inputWindowSeconds: 5
   onGameStateChanged:
@@ -2615,23 +2615,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  onGamePolicyChanged:
-    m_PersistentCalls:
-      m_Calls: []
   onInputWindowChanged:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 346280222}
-        m_MethodName: OnInputWindowChanged
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
   onGameTimeUpdate:
     m_PersistentCalls:
       m_Calls:
@@ -2656,6 +2642,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 838a35a33eda1214dae6a5ed6f1d4082, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1552617763
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1552617760}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 22e003df3703bd24da2d1556bf192498, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!4 &1552617764
@@ -3248,14 +3246,14 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2114846532}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 768faef92dd659246b264b7299bfa39c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   sequenceTimeLimit_ms: 2
   deadzoneTimeLimit_ms: 2
-  keyboardSequence: 0
+  keyboardSequence: 3
   onKeySequenceFinished:
     m_PersistentCalls:
       m_Calls:
@@ -3319,7 +3317,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2114846532}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d076990866d7a2046b67a6ba7a899656, type: 3}
   m_Name: 

--- a/Assets/SoundManager.cs
+++ b/Assets/SoundManager.cs
@@ -25,10 +25,10 @@ public class SoundManager : MonoBehaviour
     }
 
     public void OnGameDecision(GameDecisionData decisionData) {
-        if (decisionData.decision == InputTypes.AcceptAllInput) {
+        if (decisionData.decision == TrialType.AccInput) {
             audioSource.PlayOneShot(correctSound,0.75f);
             soundState = SoundState.CorrectSound;
-        } else if (decisionData.decision == InputTypes.FabInput) {
+        } else if (decisionData.decision == TrialType.FabInput) {
             audioSource.PlayOneShot(correctSound,0.75f);
             soundState = SoundState.CorrectSound;
         } else {

--- a/Assets/UrnModel.cs
+++ b/Assets/UrnModel.cs
@@ -1,0 +1,152 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class UrnEntryType {
+    public string name;
+    public UrnEntryBehavior behavior = UrnEntryBehavior.Override;
+    public int count = -1;
+}
+
+public enum UrnEntryBehavior {
+    Override,
+    Persist
+}
+
+public class UrnModel : MonoBehaviour
+{
+
+
+
+    // EntryTypes contain the different types of entries the urn generates the order from.
+    private Dictionary<string,UrnEntryType> entryTypes = new Dictionary<string, UrnEntryType>();
+    // DesignedOrder becomes smaller as entries are drawn from the urn.
+    private List<string> designedOrder = new List<string>();
+    // ResultedOrder contains the result when entries are drawn from the urn.
+    private List<string> resultedOrder = new List<string>();
+
+    private int index = -1;
+
+    public void NewUrn() {
+        index = 0;
+        CreateNewOrder();
+    }
+
+    public void AddUrnEntryType(string name, UrnEntryBehavior behavior, int count) {
+        var entryType = new UrnEntryType();
+        entryType.name = name;
+        entryType.behavior = behavior;
+        entryType.count = count;
+        entryTypes.Add(entryType.name, entryType);
+    }
+
+    public int GetIndex() {
+        return index;
+    }
+
+    public string ReadEntry() {
+        if (index >= designedOrder.Count) {
+            return null;
+        }
+        return designedOrder[index];
+    }
+
+    public void SetEntryResult(string result) {
+        resultedOrder[index] = result;
+
+        if (result == designedOrder[index]) {
+            index++;
+            return;
+        } else {
+            string entryName = designedOrder[index];
+            if (entryTypes[entryName].behavior == UrnEntryBehavior.Persist) {
+                OverrideEntryInOrder(entryName);
+            }
+            index++;
+            Debug.Log("New Resulted Order: " + ListToString(resultedOrder));
+            Debug.Log("New Designed Order: " + ListToString(designedOrder));
+        }
+    }
+
+    public Dictionary<string,int> GetEntriesLeft() {
+        var entriesLeft = new Dictionary<string, int>();
+
+        foreach (KeyValuePair<string, UrnEntryType> pair in entryTypes) {
+            var entryType = pair.Value;
+            entriesLeft[entryType.name] = 0;
+        }
+
+        foreach(string name in designedOrder) {
+            entriesLeft[name]++;
+        }
+
+        foreach(string name in resultedOrder) {
+            if (name != "None") {
+                if (entriesLeft[name] != 0) entriesLeft[name]--;
+            }
+        }
+
+        return entriesLeft;
+    }
+
+    public Dictionary<string,int> GetEntryResults() {
+        var entryResults = new Dictionary<string, int>();
+
+        foreach (KeyValuePair<string, UrnEntryType> pair in entryTypes) {
+            var entryType = pair.Value;
+            entryResults[entryType.name] = 0;
+        }
+
+        foreach(string name in resultedOrder) {
+            if (name != "None") {
+                entryResults[name]++;
+            }
+        }
+        return entryResults;
+    }
+
+    private void CreateNewOrder() {
+        designedOrder.Clear();
+
+        if (entryTypes.Count == 0) {
+            Debug.LogError("No urn entry types registered. Use AddUrnEntryType() to register new entry types.");
+            return;
+        }
+
+        // Add the desired amount of entries to designed order.
+        foreach (KeyValuePair<string, UrnEntryType> pair in entryTypes) {
+            var entryType = pair.Value;
+            for (int i = 0; i < entryType.count; i++) {
+                designedOrder.Add(entryType.name);
+                resultedOrder.Add("None");
+            }
+        }
+
+        // Shuffle the items.
+        Utils.Shuffle(designedOrder);
+        Debug.Log("New Designed Order: " + ListToString(designedOrder));
+    }
+
+    private void OverrideEntryInOrder(string entryName) {
+        string name;
+        for (int i = index; i < designedOrder.Count; i++) {
+            name = designedOrder[i];
+            if (entryTypes[name].behavior == UrnEntryBehavior.Override) {
+                Debug.Log("Overwriting " + name + " with " + entryName + "at position " + i.ToString());
+                designedOrder[i] = entryName;
+                return;
+            }
+        }
+        Debug.LogWarning("Warning: No more override entries available.");
+        return;
+    }
+
+    private string ListToString(List<string> theList) {
+        string theString = "";
+        foreach (var i in theList) {
+            theString += i + " ";
+        }
+        return ("[ " + theString + " ] (" + theList.Count + ")");
+    }
+
+}

--- a/Assets/UrnModel.cs.meta
+++ b/Assets/UrnModel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 22e003df3703bd24da2d1556bf192498
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3967945/96223962-127f3a80-0f8f-11eb-8748-93cfd2c53ed2.png)

This is a revamp of the GameManager with support for a new Urn Model.
- Removal of Game Policies all-together.
- Renaming "InputTypes" and "SetupTypes" to "TrialTypes"
- No more handling of input orders. This is now delegated to the separate class UrnModel.
- Dont handle amounts of fab/acc/rej in decimal values. We dont want the computer's rounding errors in division to decide the imbalance in our experiments.

InputTypes → TrialTypes renames:
- InputTypes.AcceptAllInput → TrialTypes.AccInput
- InputTypes.RejectAllInput → TrialTypes.RejInput
- InputTypes.FabInput → TrialTypes.FabInput